### PR TITLE
Add GitHub Actions Workflow for Automatic Release Creation on Tag

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -1,0 +1,24 @@
+name: Create Release on Tag
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Create GitHub Release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref_name }}
+        release_name: "${{ github.ref_name }}"
+        draft: false
+        prerelease: false
+        generate_release_notes: true


### PR DESCRIPTION
Description

This pull request introduces a new GitHub Actions workflow that automates the process of creating a release when a tag is pushed to the repository. The key functionality includes:

	•	Automatic Release Creation: When a new tag is pushed, the workflow will trigger and automatically create a release corresponding to the tag.
	•	Release Name: The release name is set as <tag_name>, where <tag_name> is the version or tag (e.g., 1.8 for tag 1.8).
	•	Automatic Release Notes: The workflow will automatically generate release notes based on commits, pull requests, and issues associated with the tag.
	•	Non-draft and Non-prerelease: The release will be marked as a fully published release (not a draft or a pre-release).

Workflow Details

The workflow file is located at .github/workflows/release-on-tag.yml and contains the following steps:

	•	Triggers: The workflow is triggered by a push to a tag (*) in the repository.
	•	Actions Used:
	•	actions/checkout@v3 to check out the repository code.
	•	actions/create-release@v1 to create a release based on the tag.
	•	Environment Variable: The workflow uses the ${{ secrets.GITHUB_TOKEN }} to authenticate the API calls necessary for creating the release.

How It Works

	1.	Push a new tag to the repository (e.g., git tag 1.8 && git push origin 1.8).
	2.	The workflow will automatically create a release titled Release 1.8.
	3.	GitHub will generate the release notes based on the commits and pull requests between the previous tag and the new tag.

Example

For a tag 1.8, the workflow will:

	•	Create a release named Release 1.8.
	•	Automatically generate release notes for that release.

File Added

	•	.github/workflows/release-on-tag.yml