### PR TITLE
Handle Display Zoom screenshot resolution conflicts

### DIFF
--- a/Shotbot/Shortcuts/CreateFramedScreenshotsIntent.swift
+++ b/Shotbot/Shortcuts/CreateFramedScreenshotsIntent.swift
@@ -104,12 +104,24 @@ public struct CreateFramedScreenshotsIntent: AppIntent {
             logger.error("Data could not be turned into a UIImage")
             throw SBError.unsupportedImage
         }
-                
-        guard let device = DeviceInfo.all().first(where: {$0.inputSize == screenshot.size}) else {
+
+        let device: DeviceInfo
+
+        switch DeviceInfo.match(for: screenshot.size) {
+        case .exact(let d):
+            device = d
+        case .ambiguous(let options):
+            let cached = await PersistenceManager.shared.preferredDeviceFrame(for: screenshot.size)
+            guard let resolved = options.first(where: { $0.deviceFrame == cached }) ?? options.first else {
+                logger.error("Could not resolve ambiguous device for width: \(screenshot.size.width, privacy: .public) and height: \(screenshot.size.height, privacy: .public).")
+                throw SBError.unsupportedDevice
+            }
+            device = resolved
+        case .none:
             logger.error("Could not find an image with width: \(screenshot.size.width, privacy: .public) and height: \(screenshot.size.height, privacy: .public).")
             throw SBError.unsupportedDevice
         }
-        
+
         guard let image = device.framed(using: screenshot)?.scaled(to: imageQuality.value) else {
             logger.error("Could not frame image.")
             throw SBError.framing

--- a/ShotbotCore/Package.resolved
+++ b/ShotbotCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "98e22325f843c7b7c3276fe367087c3bb2874b9b392829eb1d7974a24635379c",
+  "originHash" : "2228cc4e85f0ebb33bbf7e3c7660ef9509b2fa7855c2e2625ef9860d47bb109c",
   "pins" : [
     {
       "identity" : "alerttoast",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Rspoon3/ReferralService-iOS.git",
       "state" : {
-        "branch" : "swift-6",
-        "revision" : "4f96d944968c930d1260fd01aa15a3dea25c7dc3"
+        "revision" : "1f1178effbb46b01e5b406870349edb234cdd8f2",
+        "version" : "1.0.0"
       }
     },
     {

--- a/ShotbotCore/Sources/HomeFeature/HomeView/DeviceDisambiguationView.swift
+++ b/ShotbotCore/Sources/HomeFeature/HomeView/DeviceDisambiguationView.swift
@@ -1,0 +1,76 @@
+//
+//  DeviceDisambiguationView.swift
+//  Shotbot
+//
+//  Created by Richard Witherspoon on 3/28/26.
+//
+
+import SwiftUI
+import Models
+
+/// A sheet that lets the user pick the correct device when a screenshot's resolution is ambiguous.
+struct DeviceDisambiguationView: View {
+    private let devices: [DeviceInfo]
+    private let screenshot: UIImage
+    private let onSelect: (DeviceInfo) -> Void
+
+    // MARK: - Initializer
+
+    init(devices: [DeviceInfo], screenshot: UIImage, onSelect: @escaping (DeviceInfo) -> Void) {
+        self.devices = devices
+        self.screenshot = screenshot
+        self.onSelect = onSelect
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        NavigationStack {
+            List(devices, id: \.deviceFrame) { device in
+                Button {
+                    onSelect(device)
+                } label: {
+                    DeviceRow(device: device)
+                }
+            }
+            .navigationTitle("Select Device")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+        .presentationDetents([.medium])
+        .interactiveDismissDisabled()
+    }
+
+    // MARK: - Private Views
+
+    private func DeviceRow(device: DeviceInfo) -> some View {
+        HStack(spacing: 16) {
+            if let framedImage = device.framed(using: screenshot) {
+                Image(uiImage: framedImage)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(height: 120)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(device.displayName)
+                    .font(.headline)
+
+                if let scaledSize = device.scaledSize {
+                    Text("Display Zoom")
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+
+                    Text("Native: \(Int(scaledSize.width)) × \(Int(scaledSize.height))")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("\(Int(device.inputSize.width)) × \(Int(device.inputSize.height))")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.vertical, 4)
+    }
+}

--- a/ShotbotCore/Sources/HomeFeature/HomeView/DeviceDisambiguationView.swift
+++ b/ShotbotCore/Sources/HomeFeature/HomeView/DeviceDisambiguationView.swift
@@ -26,17 +26,23 @@ struct DeviceDisambiguationView: View {
 
     var body: some View {
         NavigationStack {
-            List(devices, id: \.deviceFrame) { device in
-                Button {
-                    onSelect(device)
-                } label: {
-                    DeviceRow(device: device)
+            List {
+                Section {
+                    ForEach(devices, id: \.deviceFrame) { device in
+                        Button {
+                            onSelect(device)
+                        } label: {
+                            DeviceRow(device: device)
+                        }
+                    }
+                } header: {
+                    Text("This screenshot's resolution matches multiple devices. Select the device this screenshot was taken on.")
                 }
             }
             .navigationTitle("Select Device")
             .navigationBarTitleDisplayMode(.inline)
         }
-        .presentationDetents([.medium])
+        .presentationDetents([.medium, .large])
         .interactiveDismissDisabled()
     }
 

--- a/ShotbotCore/Sources/HomeFeature/HomeView/HomeView.swift
+++ b/ShotbotCore/Sources/HomeFeature/HomeView/HomeView.swift
@@ -177,6 +177,17 @@ public struct HomeView: View {
             allowedContentTypes: [.image, .png, .jpeg],
             allowsMultipleSelection: true
         ) { viewModel.fileImportCompletion(result: $0) }
+        .confirmationDialog(
+            "Which device is this screenshot from?",
+            isPresented: $viewModel.showDeviceDisambiguation,
+            titleVisibility: .visible
+        ) {
+            ForEach(viewModel.ambiguousDeviceOptions, id: \.deviceFrame) { device in
+                Button(device.displayName) {
+                    viewModel.didSelectDisambiguatedDevice(device)
+                }
+            }
+        }
     }
     
     @ViewBuilder

--- a/ShotbotCore/Sources/HomeFeature/HomeView/HomeView.swift
+++ b/ShotbotCore/Sources/HomeFeature/HomeView/HomeView.swift
@@ -177,13 +177,12 @@ public struct HomeView: View {
             allowedContentTypes: [.image, .png, .jpeg],
             allowsMultipleSelection: true
         ) { viewModel.fileImportCompletion(result: $0) }
-        .confirmationDialog(
-            "Which device is this screenshot from?",
-            isPresented: $viewModel.showDeviceDisambiguation,
-            titleVisibility: .visible
-        ) {
-            ForEach(viewModel.ambiguousDeviceOptions, id: \.deviceFrame) { device in
-                Button(device.displayName) {
+        .sheet(isPresented: $viewModel.showDeviceDisambiguation) {
+            if let screenshot = viewModel.disambiguationScreenshot {
+                DeviceDisambiguationView(
+                    devices: viewModel.ambiguousDeviceOptions,
+                    screenshot: screenshot
+                ) { device in
                     viewModel.didSelectDisambiguatedDevice(device)
                 }
             }

--- a/ShotbotCore/Sources/HomeFeature/HomeView/HomeViewModel.swift
+++ b/ShotbotCore/Sources/HomeFeature/HomeView/HomeViewModel.swift
@@ -59,6 +59,7 @@ import SwiftTools
     }
     @Published public var showDeviceDisambiguation = false
     @Published public var ambiguousDeviceOptions: [DeviceInfo] = []
+    @Published public var disambiguationScreenshot: UIImage?
     private var disambiguationContinuation: CheckedContinuation<DeviceInfo, Never>?
     
     var showLoadingSpinner: Bool {
@@ -341,7 +342,8 @@ import SwiftTools
     ///
     /// Checks the cached preference first. If no preference exists and the match is
     /// ambiguous, presents a confirmation dialog and awaits the user's selection.
-    private func resolveDevice(for screenshotSize: CGSize) async -> DeviceInfo? {
+    private func resolveDevice(for screenshot: UIImage) async -> DeviceInfo? {
+        let screenshotSize = screenshot.size
         let result = DeviceInfo.match(for: screenshotSize)
 
         switch result {
@@ -356,6 +358,7 @@ import SwiftTools
             }
 
             ambiguousDeviceOptions = options
+            disambiguationScreenshot = screenshot
             showDeviceDisambiguation = true
 
             let chosen = await withCheckedContinuation { continuation in
@@ -371,6 +374,7 @@ import SwiftTools
     public func didSelectDisambiguatedDevice(_ device: DeviceInfo) {
         disambiguationContinuation?.resume(returning: device)
         disambiguationContinuation = nil
+        disambiguationScreenshot = nil
         showDeviceDisambiguation = false
     }
 
@@ -378,7 +382,7 @@ import SwiftTools
     ///
     /// Will auto save to files or photos if necessary
     private func createDeviceFrame(using screenshot: UIScreenshot, count: Int) async throws -> ShareableImage {
-        guard let device = await resolveDevice(for: screenshot.size) else {
+        guard let device = await resolveDevice(for: screenshot) else {
             throw SBError.unsupportedImage
         }
         let framedScreenshot = try screenshot.framedScreenshot(quality: persistenceManager.imageQuality, device: device)

--- a/ShotbotCore/Sources/HomeFeature/HomeView/HomeViewModel.swift
+++ b/ShotbotCore/Sources/HomeFeature/HomeView/HomeViewModel.swift
@@ -57,6 +57,9 @@ import SwiftTools
             isLoading = false
         }
     }
+    @Published public var showDeviceDisambiguation = false
+    @Published public var ambiguousDeviceOptions: [DeviceInfo] = []
+    private var disambiguationContinuation: CheckedContinuation<DeviceInfo, Never>?
     
     var showLoadingSpinner: Bool {
         isLoading && viewState != .combinedPlaceholder
@@ -334,11 +337,51 @@ import SwiftTools
         }
     }
     
+    /// Resolves the correct `DeviceInfo` for a screenshot, prompting the user when ambiguous.
+    ///
+    /// Checks the cached preference first. If no preference exists and the match is
+    /// ambiguous, presents a confirmation dialog and awaits the user's selection.
+    private func resolveDevice(for screenshotSize: CGSize) async -> DeviceInfo? {
+        let result = DeviceInfo.match(for: screenshotSize)
+
+        switch result {
+        case .exact(let device):
+            return device
+        case .none:
+            return nil
+        case .ambiguous(let options):
+            if let cached = persistenceManager.preferredDeviceFrame(for: screenshotSize),
+               let device = options.first(where: { $0.deviceFrame == cached }) {
+                return device
+            }
+
+            ambiguousDeviceOptions = options
+            showDeviceDisambiguation = true
+
+            let chosen = await withCheckedContinuation { continuation in
+                disambiguationContinuation = continuation
+            }
+
+            persistenceManager.setPreferredDeviceFrame(chosen.deviceFrame, for: screenshotSize)
+            return chosen
+        }
+    }
+
+    /// Called by the disambiguation dialog when the user selects a device.
+    public func didSelectDisambiguatedDevice(_ device: DeviceInfo) {
+        disambiguationContinuation?.resume(returning: device)
+        disambiguationContinuation = nil
+        showDeviceDisambiguation = false
+    }
+
     /// Creates a `ShareableImage` from a `UIScreenshot`
     ///
     /// Will auto save to files or photos if necessary
     private func createDeviceFrame(using screenshot: UIScreenshot, count: Int) async throws -> ShareableImage {
-        let framedScreenshot = try screenshot.framedScreenshot(quality: persistenceManager.imageQuality)
+        guard let device = await resolveDevice(for: screenshot.size) else {
+            throw SBError.unsupportedImage
+        }
+        let framedScreenshot = try screenshot.framedScreenshot(quality: persistenceManager.imageQuality, device: device)
         let path = "Framed Screenshot \(count)_\(UUID()).png"
         let temporaryURL = URL.temporaryDirectory.appending(path: path)
         

--- a/ShotbotCore/Sources/HomeFeature/HomeView/HomeViewModel.swift
+++ b/ShotbotCore/Sources/HomeFeature/HomeView/HomeViewModel.swift
@@ -352,7 +352,8 @@ import SwiftTools
         case .none:
             return nil
         case .ambiguous(let options):
-            if let cached = persistenceManager.preferredDeviceFrame(for: screenshotSize),
+            if !persistenceManager.alwaysAskDeviceFrame,
+               let cached = persistenceManager.preferredDeviceFrame(for: screenshotSize),
                let device = options.first(where: { $0.deviceFrame == cached }) {
                 return device
             }

--- a/ShotbotCore/Sources/Models/DeviceInfo.swift
+++ b/ShotbotCore/Sources/Models/DeviceInfo.swift
@@ -63,8 +63,13 @@ public struct DeviceInfo: Decodable, Sendable {
         return name
     }
 
+    /// The device frame asset image, if available.
+    public var frameImage: UIImage? {
+        UIImage(named: deviceFrame, in: .module, with: nil)
+    }
+
     // MARK: - Functions
-    
+
     public func framed(using screenshot: UIImage) -> UIImage? {
         var screenshot = screenshot
         let offSet = offSet ?? .zero

--- a/ShotbotCore/Sources/Models/DeviceInfo.swift
+++ b/ShotbotCore/Sources/Models/DeviceInfo.swift
@@ -8,7 +8,7 @@
 import UIKit
 import SwiftTools
 
-public struct DeviceInfo: Decodable {
+public struct DeviceInfo: Decodable, Sendable {
     public let deviceFrame: String
     public let mergeMethod: MergeMethod
     public let clipEdgesAmount: CGFloat?
@@ -16,9 +16,13 @@ public struct DeviceInfo: Decodable {
     public let inputSize: CGSize
     public let scaledSize: CGSize?
     public let offSet: CGPoint?
-    
+
+    /// The screenshot resolution produced when Display Zoom is enabled on this device.
+    /// When present, this resolution may collide with another device's native `inputSize`.
+    public let displayZoomInputSize: CGSize?
+
     // MARK: - Initializer
-    
+
     public init(
         deviceFrame: String,
         mergeMethod: MergeMethod,
@@ -26,7 +30,8 @@ public struct DeviceInfo: Decodable {
         cornerRadius: CGFloat?,
         inputSize: CGSize,
         scaledSize: CGSize?,
-        offSet: CGPoint?
+        offSet: CGPoint?,
+        displayZoomInputSize: CGSize? = nil
     ) {
         self.deviceFrame = deviceFrame
         self.mergeMethod = mergeMethod
@@ -35,8 +40,29 @@ public struct DeviceInfo: Decodable {
         self.scaledSize = scaledSize
         self.offSet = offSet
         self.cornerRadius = cornerRadius
+        self.displayZoomInputSize = displayZoomInputSize
     }
     
+    /// A user-friendly device name extracted from the frame identifier.
+    ///
+    /// Strips orientation and color suffixes:
+    /// - "iPhone Air - Space Black - Portrait" → "iPhone Air"
+    /// - "iPhone 11 Pro Portrait" → "iPhone 11 Pro"
+    public var displayName: String {
+        var name = deviceFrame
+            .components(separatedBy: " - ")
+            .first?
+            .trimmingCharacters(in: .whitespaces) ?? deviceFrame
+
+        for suffix in [" Portrait", " Landscape"] {
+            if name.hasSuffix(suffix) {
+                name = String(name.dropLast(suffix.count))
+            }
+        }
+
+        return name
+    }
+
     // MARK: - Functions
     
     public func framed(using screenshot: UIImage) -> UIImage? {
@@ -80,12 +106,57 @@ public struct DeviceInfo: Decodable {
     
     public static func all() -> [DeviceInfo] {
         let bundle = Bundle.module
-        
+
         let iPhoneFrames = try! bundle.decode([DeviceInfo].self, from: "iPhoneFrames.json")
         let iPadFrames = try! bundle.decode([DeviceInfo].self, from: "iPadFrames.json")
         let macFrames = try! bundle.decode([DeviceInfo].self, from: "MacFrames.json")
         let AppleWatchFrames = try! bundle.decode([DeviceInfo].self, from: "AppleWatchFrames.json")
-        
+
         return iPhoneFrames + iPadFrames + macFrames + AppleWatchFrames
     }
+
+    /// Matches a screenshot size against all known devices, accounting for Display Zoom.
+    ///
+    /// Returns `.ambiguous` when the size matches both a device's native `inputSize`
+    /// and another device's `displayZoomInputSize`, requiring user disambiguation.
+    public static func match(for screenshotSize: CGSize) -> DeviceMatchResult {
+        let devices = all()
+        var matches: [DeviceInfo] = []
+
+        // Check direct inputSize matches
+        if let direct = devices.first(where: { $0.inputSize == screenshotSize }) {
+            matches.append(direct)
+        }
+
+        // Check display zoom matches — create a synthetic DeviceInfo with scaledSize
+        // so the existing framed(using:) method resizes the zoomed screenshot to native
+        for device in devices where device.displayZoomInputSize == screenshotSize {
+            let zoomDevice = DeviceInfo(
+                deviceFrame: device.deviceFrame,
+                mergeMethod: device.mergeMethod,
+                clipEdgesAmount: device.clipEdgesAmount,
+                cornerRadius: device.cornerRadius,
+                inputSize: screenshotSize,
+                scaledSize: device.inputSize,
+                offSet: device.offSet
+            )
+            matches.append(zoomDevice)
+        }
+
+        switch matches.count {
+        case 0: return .none
+        case 1: return .exact(matches[0])
+        default: return .ambiguous(matches)
+        }
+    }
+}
+
+/// The result of matching a screenshot's dimensions against known device configurations.
+public enum DeviceMatchResult {
+    /// Exactly one device matches the screenshot size.
+    case exact(DeviceInfo)
+    /// Multiple devices claim this resolution (e.g., native + display zoom conflict).
+    case ambiguous([DeviceInfo])
+    /// No known device matches this screenshot size.
+    case none
 }

--- a/ShotbotCore/Sources/Models/Extensions/UIImage+Extension.swift
+++ b/ShotbotCore/Sources/Models/Extensions/UIImage+Extension.swift
@@ -176,15 +176,28 @@ public extension UIImage {
         }
     }
     
-    /// Creates a framed screenshot based on the image quality passed in
+    /// Creates a framed screenshot based on the image quality passed in.
+    ///
+    /// Only succeeds for unambiguous device matches. For ambiguous matches
+    /// (e.g., Display Zoom conflicts), use the overload that accepts a `DeviceInfo`.
     func framedScreenshot(quality: ImageQuality) throws -> UIFramedScreenshot {
-        guard
-            let device = DeviceInfo.all().first(where: {$0.inputSize == size}),
-            let framedScreenshot = device.framed(using: self)?.scaled(to: quality.value)
+        let result = DeviceInfo.match(for: size)
+
+        guard case .exact(let device) = result,
+              let framedScreenshot = device.framed(using: self)?.scaled(to: quality.value)
         else {
             throw SBError.unsupportedImage
         }
-        
+
+        return framedScreenshot
+    }
+
+    /// Creates a framed screenshot using a pre-resolved device.
+    func framedScreenshot(quality: ImageQuality, device: DeviceInfo) throws -> UIFramedScreenshot {
+        guard let framedScreenshot = device.framed(using: self)?.scaled(to: quality.value) else {
+            throw SBError.unsupportedImage
+        }
+
         return framedScreenshot
     }
 }

--- a/ShotbotCore/Sources/Models/MergeMethod.swift
+++ b/ShotbotCore/Sources/Models/MergeMethod.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum MergeMethod: String, Decodable {
+public enum MergeMethod: String, Decodable, Sendable {
     case singleOverlay
     case singleOverlayV2
     case doubleOverlay

--- a/ShotbotCore/Sources/Models/Resources/JSON/iPhoneFrames.json
+++ b/ShotbotCore/Sources/Models/Resources/JSON/iPhoneFrames.json
@@ -106,6 +106,7 @@
         "mergeMethod": "islandOverlay",
         "clipEdgesAmount": 75,
         "inputSize": [1290, 2796],
+        "displayZoomInputSize": [1125, 2436],
         "offSet": [80, 70],
     },
     {
@@ -113,6 +114,7 @@
         "mergeMethod": "islandOverlay",
         "clipEdgesAmount": 75,
         "inputSize": [2796, 1290],
+        "displayZoomInputSize": [2436, 1125],
         "offSet": [70, 80],
     },
     {

--- a/ShotbotCore/Sources/Models/Resources/JSON/iPhoneFrames.json
+++ b/ShotbotCore/Sources/Models/Resources/JSON/iPhoneFrames.json
@@ -143,12 +143,14 @@
         "deviceFrame": "iPhone Air - Space Black - Portrait",
         "mergeMethod": "singleOverlayV2",
         "cornerRadius": 100,
-        "inputSize": [1260, 2736]
+        "inputSize": [1260, 2736],
+        "displayZoomInputSize": [1125, 2436]
     },
     {
         "deviceFrame": "iPhone Air - Space Black - Landscape",
         "mergeMethod": "singleOverlayV2",
         "cornerRadius": 100,
-        "inputSize": [2736, 1260]
+        "inputSize": [2736, 1260],
+        "displayZoomInputSize": [2436, 1125]
     },
 ]

--- a/ShotbotCore/Sources/Persistence/PersistenceManager.swift
+++ b/ShotbotCore/Sources/Persistence/PersistenceManager.swift
@@ -100,6 +100,9 @@ public final class PersistenceManager: ObservableObject, PersistenceManaging, @u
 
     // MARK: - Device Frame Preferences
 
+    @AppStorage("alwaysAskDeviceFrame")
+    public var alwaysAskDeviceFrame: Bool = false
+
     @AppStorage("deviceFramePreferences")
     private var deviceFramePreferencesData: Data = Data()
 
@@ -164,6 +167,7 @@ public class MockPersistenceManager: PersistenceManaging, @unchecked Sendable {
     public var creditBalance: Int = 0
     public var canEnterReferralCode: Bool = true
     public var referralBannerCount: Int = 0
+    public var alwaysAskDeviceFrame: Bool = false
     private var mockDeviceFramePreferences: [String: String] = [:]
 
     public init() {}

--- a/ShotbotCore/Sources/Persistence/PersistenceManager.swift
+++ b/ShotbotCore/Sources/Persistence/PersistenceManager.swift
@@ -93,9 +93,56 @@ public final class PersistenceManager: ObservableObject, PersistenceManaging, @u
     @AppStorage("subscriptionOverride", store: .shared)
     public var subscriptionOverride: SubscriptionOverrideMethod = .appStore
 #endif
-    
+
     public func setLastReviewPromptDateToNow() {
         lastReviewPromptDate = .now
+    }
+
+    // MARK: - Device Frame Preferences
+
+    @AppStorage("deviceFramePreferences")
+    private var deviceFramePreferencesData: Data = Data()
+
+    private var deviceFramePreferencesDict: [String: String] {
+        get {
+            guard !deviceFramePreferencesData.isEmpty else { return [:] }
+            return (try? JSONDecoder().decode([String: String].self, from: deviceFramePreferencesData)) ?? [:]
+        }
+        set {
+            deviceFramePreferencesData = (try? JSONEncoder().encode(newValue)) ?? Data()
+        }
+    }
+
+    private static func sizeKey(for size: CGSize) -> String {
+        "\(Int(size.width))x\(Int(size.height))"
+    }
+
+    public func preferredDeviceFrame(for size: CGSize) -> String? {
+        deviceFramePreferencesDict[Self.sizeKey(for: size)]
+    }
+
+    public func setPreferredDeviceFrame(_ frameName: String, for size: CGSize) {
+        var dict = deviceFramePreferencesDict
+        dict[Self.sizeKey(for: size)] = frameName
+        deviceFramePreferencesDict = dict
+    }
+
+    public func clearDeviceFramePreferences() {
+        deviceFramePreferencesData = Data()
+    }
+
+    public func removeDeviceFramePreference(for size: CGSize) {
+        var dict = deviceFramePreferencesDict
+        dict.removeValue(forKey: Self.sizeKey(for: size))
+        deviceFramePreferencesDict = dict
+    }
+
+    public var hasDeviceFramePreferences: Bool {
+        !deviceFramePreferencesDict.isEmpty
+    }
+
+    public var deviceFramePreferences: [String: String] {
+        deviceFramePreferencesDict
     }
 }
 
@@ -117,6 +164,7 @@ public class MockPersistenceManager: PersistenceManaging, @unchecked Sendable {
     public var creditBalance: Int = 0
     public var canEnterReferralCode: Bool = true
     public var referralBannerCount: Int = 0
+    private var mockDeviceFramePreferences: [String: String] = [:]
 
     public init() {}
 
@@ -138,6 +186,31 @@ public class MockPersistenceManager: PersistenceManaging, @unchecked Sendable {
         creditBalance = 0
         referralBannerCount = 0
         canEnterReferralCode = true
+        mockDeviceFramePreferences = [:]
+    }
+
+    public func preferredDeviceFrame(for size: CGSize) -> String? {
+        mockDeviceFramePreferences["\(Int(size.width))x\(Int(size.height))"]
+    }
+
+    public func setPreferredDeviceFrame(_ frameName: String, for size: CGSize) {
+        mockDeviceFramePreferences["\(Int(size.width))x\(Int(size.height))"] = frameName
+    }
+
+    public func clearDeviceFramePreferences() {
+        mockDeviceFramePreferences = [:]
+    }
+
+    public func removeDeviceFramePreference(for size: CGSize) {
+        mockDeviceFramePreferences.removeValue(forKey: "\(Int(size.width))x\(Int(size.height))")
+    }
+
+    public var hasDeviceFramePreferences: Bool {
+        !mockDeviceFramePreferences.isEmpty
+    }
+
+    public var deviceFramePreferences: [String: String] {
+        mockDeviceFramePreferences
     }
     
     public func setLastReviewPromptDateToNow() {

--- a/ShotbotCore/Sources/Persistence/PersistenceManaging.swift
+++ b/ShotbotCore/Sources/Persistence/PersistenceManaging.swift
@@ -27,4 +27,24 @@ public protocol PersistenceManaging: Sendable {
     var creditBalance: Int { get set }
     var canEnterReferralCode: Bool { get set }
     func setLastReviewPromptDateToNow()
+
+    // MARK: - Device Frame Preferences
+
+    /// Returns the user's preferred device frame name for the given screenshot size, if cached.
+    func preferredDeviceFrame(for size: CGSize) -> String?
+
+    /// Stores the user's preferred device frame name for the given screenshot size.
+    func setPreferredDeviceFrame(_ frameName: String, for size: CGSize)
+
+    /// Removes all cached device frame preferences.
+    func clearDeviceFramePreferences()
+
+    /// Removes the cached device frame preference for the given screenshot size.
+    func removeDeviceFramePreference(for size: CGSize)
+
+    /// Whether any device frame preferences have been cached.
+    var hasDeviceFramePreferences: Bool { get }
+
+    /// All cached device frame preferences keyed by size string (e.g. "1170x2532") mapped to the device frame name.
+    var deviceFramePreferences: [String: String] { get }
 }

--- a/ShotbotCore/Sources/Persistence/PersistenceManaging.swift
+++ b/ShotbotCore/Sources/Persistence/PersistenceManaging.swift
@@ -30,6 +30,9 @@ public protocol PersistenceManaging: Sendable {
 
     // MARK: - Device Frame Preferences
 
+    /// When true, always prompt for device selection on ambiguous matches instead of using cached preferences.
+    var alwaysAskDeviceFrame: Bool { get set }
+
     /// Returns the user's preferred device frame name for the given screenshot size, if cached.
     func preferredDeviceFrame(for size: CGSize) -> String?
 

--- a/ShotbotCore/Sources/SettingsFeature/DeviceFramePreferencesView.swift
+++ b/ShotbotCore/Sources/SettingsFeature/DeviceFramePreferencesView.swift
@@ -24,7 +24,7 @@ struct DeviceFramePreferencesView: View {
             }
 
             if !sortedPreferences.isEmpty {
-                Section("Saved Preferences") {
+                Section {
                     ForEach(sortedPreferences, id: \.key) { key, deviceFrame in
                         VStack(alignment: .leading, spacing: 4) {
                             Text(deviceFrame)
@@ -44,13 +44,11 @@ struct DeviceFramePreferencesView: View {
                             removePreference(forKey: key)
                         }
                     }
+                } header: {
+                    Text("Saved Preferences")
+                } footer: {
+                    Text("Shotbot matches screenshots to device frames using image resolution. This is the only reliable information a screenshot contains. Certain settings, such as Display Zoom, can cause a screenshot's resolution to match a different device, resulting in the wrong frame being applied. When this happens, you can choose the correct device and Shotbot will remember your preference.")
                 }
-            }
-
-            Section {
-                EmptyView()
-            } footer: {
-                Text("Shotbot matches screenshots to device frames using image resolution. This is the only reliable information a screenshot contains. Certain settings, such as Display Zoom, can cause a screenshot's resolution to match a different device, resulting in the wrong frame being applied. When this happens, you can choose the correct device and Shotbot will remember your preference.")
             }
         }
         .navigationTitle("Device Frame Preferences")

--- a/ShotbotCore/Sources/SettingsFeature/DeviceFramePreferencesView.swift
+++ b/ShotbotCore/Sources/SettingsFeature/DeviceFramePreferencesView.swift
@@ -18,25 +18,37 @@ struct DeviceFramePreferencesView: View {
     var body: some View {
         List {
             Section {
-                ForEach(sortedPreferences, id: \.key) { key, deviceFrame in
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(deviceFrame)
-                        Text(key)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+                Toggle("Always ask", isOn: $persistenceManager.alwaysAskDeviceFrame)
+            } footer: {
+                Text("When enabled, Shotbot will always ask which device to use when a screenshot's resolution matches multiple devices, instead of using your saved preference.")
+            }
+
+            if !sortedPreferences.isEmpty {
+                Section("Saved Preferences") {
+                    ForEach(sortedPreferences, id: \.key) { key, deviceFrame in
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(deviceFrame)
+                            Text(key)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        .contextMenu {
+                            Button("Remove", symbol: .trash, role: .destructive) {
+                                removePreference(forKey: key)
+                            }
+                        }
                     }
-                    .contextMenu {
-                        Button("Remove", symbol: .trash, role: .destructive) {
+                    .onDelete { indexSet in
+                        for index in indexSet {
+                            let key = sortedPreferences[index].key
                             removePreference(forKey: key)
                         }
                     }
                 }
-                .onDelete { indexSet in
-                    for index in indexSet {
-                        let key = sortedPreferences[index].key
-                        removePreference(forKey: key)
-                    }
-                }
+            }
+
+            Section {
+                EmptyView()
             } footer: {
                 Text("Shotbot matches screenshots to device frames using image resolution. This is the only reliable information a screenshot contains. Certain settings, such as Display Zoom, can cause a screenshot's resolution to match a different device, resulting in the wrong frame being applied. When this happens, you can choose the correct device and Shotbot will remember your preference.")
             }

--- a/ShotbotCore/Sources/SettingsFeature/DeviceFramePreferencesView.swift
+++ b/ShotbotCore/Sources/SettingsFeature/DeviceFramePreferencesView.swift
@@ -1,0 +1,68 @@
+//
+//  DeviceFramePreferencesView.swift
+//  Shotbot
+//
+//  Created by Richard Witherspoon on 3/28/26.
+//
+
+import SwiftUI
+import Persistence
+import SFSymbols
+
+/// Displays the user's cached device frame preferences and allows removing individual entries.
+struct DeviceFramePreferencesView: View {
+    @EnvironmentObject private var persistenceManager: PersistenceManager
+
+    // MARK: - Body
+
+    var body: some View {
+        List {
+            Section {
+                ForEach(sortedPreferences, id: \.key) { key, deviceFrame in
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(deviceFrame)
+                        Text(key)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .contextMenu {
+                        Button("Remove", symbol: .trash, role: .destructive) {
+                            removePreference(forKey: key)
+                        }
+                    }
+                }
+                .onDelete { indexSet in
+                    for index in indexSet {
+                        let key = sortedPreferences[index].key
+                        removePreference(forKey: key)
+                    }
+                }
+            } footer: {
+                Text("Shotbot matches screenshots to device frames using image resolution. This is the only reliable information a screenshot contains. Certain settings, such as Display Zoom, can cause a screenshot's resolution to match a different device, resulting in the wrong frame being applied. When this happens, you can choose the correct device and Shotbot will remember your preference.")
+            }
+        }
+        .navigationTitle("Device Frame Preferences")
+    }
+
+    // MARK: - Private Helpers
+
+    private var sortedPreferences: [(key: String, value: String)] {
+        persistenceManager.deviceFramePreferences
+            .sorted(by: { $0.value < $1.value })
+    }
+
+    /// Parses a size key like "1170x2532" back into a `CGSize` and removes the preference.
+    private func removePreference(forKey key: String) {
+        let components = key.split(separator: "x")
+
+        guard
+            components.count == 2,
+            let width = Double(components[0]),
+            let height = Double(components[1])
+        else {
+            return
+        }
+
+        persistenceManager.removeDeviceFramePreference(for: CGSize(width: width, height: height))
+    }
+}

--- a/ShotbotCore/Sources/SettingsFeature/SettingsView.swift
+++ b/ShotbotCore/Sources/SettingsFeature/SettingsView.swift
@@ -93,6 +93,14 @@ public struct SettingsView: View {
                             .tag(type)
                     }
                 }
+
+                if persistenceManager.hasDeviceFramePreferences {
+                    NavigationLink {
+                        DeviceFramePreferencesView()
+                    } label: {
+                        Label("Device Frame Preferences", symbol: .rectangleOnRectangle)
+                    }
+                }
             }
             
             Section("Feedback") {

--- a/ShotbotCore/Sources/SettingsFeature/SettingsView.swift
+++ b/ShotbotCore/Sources/SettingsFeature/SettingsView.swift
@@ -94,12 +94,10 @@ public struct SettingsView: View {
                     }
                 }
 
-                if persistenceManager.hasDeviceFramePreferences {
-                    NavigationLink {
-                        DeviceFramePreferencesView()
-                    } label: {
-                        Label("Device Frame Preferences", symbol: .rectangleOnRectangle)
-                    }
+                NavigationLink {
+                    DeviceFramePreferencesView()
+                } label: {
+                    Label("Device Frame Preferences", symbol: .rectangleOnRectangle)
                 }
             }
             

--- a/ShotbotCore/Tests/ModelsTests/DeviceInfoTests.swift
+++ b/ShotbotCore/Tests/ModelsTests/DeviceInfoTests.swift
@@ -8,23 +8,23 @@
 import XCTest
 import Models
 
-final class DeviceInfoTests: XCTestCase {    
+final class DeviceInfoTests: XCTestCase {
     func testAllDeviceInputSizesAreUnique() {
         let inputSizes = DeviceInfo.all().map(\.inputSize)
         let set = Set(inputSizes)
         XCTAssertEqual(inputSizes.count, set.count)
     }
-    
+
     func testNumberOfDevices() {
         XCTAssertEqual(DeviceInfo.all().count, 43)
     }
-    
+
     func testAllDeviceFramesHaveAnAsset() {
         for device in DeviceInfo.all() {
             let image = UIImage(named: device.deviceFrame, in: .models, compatibleWith: nil)
 
             XCTAssertNotNil(image)
-            
+
             if device.mergeMethod == .islandOverlay {
                 let title = "\(device.deviceFrame) Without Island"
                 let islandImage = UIImage(named: title, in: .models, compatibleWith: nil)


### PR DESCRIPTION
## Summary

Closes #25

- Detect when a screenshot's resolution is ambiguous (e.g. Display Zoom on iPhone Air produces the same resolution as iPhone X's native size)
- Present a half-sheet with framed screenshot previews so the user can visually pick the correct device
- Persist the user's choice per resolution so they're only prompted once
- Add "Always ask" toggle to skip cached preferences and always prompt on ambiguous matches
- Add a **Device Frame Preferences** settings screen (always visible) to manage saved preferences and the always-ask toggle
- Add `displayZoomInputSize` entries for additional iPhone models
- Add `Sendable` conformance to `DeviceInfo` and `MergeMethod` to fix Swift concurrency warnings
- Update Shortcuts intent to use the new matching and preference system

## Test plan

- [ ] Take a screenshot with Display Zoom enabled on iPhone Air and import it — verify the disambiguation sheet appears with framed previews and explanatory header
- [ ] Select a device and verify the preference is saved (subsequent imports of the same resolution should auto-resolve)
- [ ] Enable "Always ask" in Device Frame Preferences and verify the sheet always appears for ambiguous resolutions
- [ ] Verify the Device Frame Preferences screen always appears in Settings
- [ ] Swipe-to-delete and context menu remove work on individual preferences
- [ ] Import a non-ambiguous screenshot and verify no disambiguation prompt appears
- [ ] Test the Shortcuts intent with an ambiguous screenshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)